### PR TITLE
Fix marker names

### DIFF
--- a/reathon/reathon/helper.py
+++ b/reathon/reathon/helper.py
@@ -5,7 +5,7 @@ def make_color(r, g, b):
     return (1 << 24) + (r << 16) + (g << 8) + b
 
 def marker(index:int, time:float, name:str, color:int=0):
-    return ['MARKER', f'{index} {time} {"name"} 0 {color} 1 B']
+    return ['MARKER', f'{index} {time} "{name}" 0 {color} 1 B']
 
 def region(index:int, start:float, end:float, name:str, color:int=0):
     return [['MARKER', f'{index} {start} "{name}" 1 {color} 1 B'], ['MARKER', f'{index} {end} ""  1 {color} 1 B']]


### PR DESCRIPTION
The quotes in the marker name were swapped with the brackets, so every marker got the name `name` instead of the provided name.